### PR TITLE
utils: add TypeError guard to find_sub_classes and extend tests

### DIFF
--- a/pylegend/utils/class_utils.py
+++ b/pylegend/utils/class_utils.py
@@ -23,6 +23,8 @@ T = PyLegendTypeVar("T")
 
 
 def find_sub_classes(clazz: PyLegendType[T], recursive: bool = True) -> PyLegendList[PyLegendType[T]]:
+    if not isinstance(clazz, type):
+        raise TypeError(f"find_sub_classes expects a class/type, got {type(clazz)!r}")
     subclasses = clazz.__subclasses__()
     if recursive:
         subclasses = subclasses + [c for s in subclasses for c in find_sub_classes(s, True)]

--- a/tests/utils/test_class_utils.py
+++ b/tests/utils/test_class_utils.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+import pytest
 from pylegend.utils.class_utils import find_sub_classes
 
 
@@ -45,3 +45,14 @@ class TestClassUtils:
         assert {D} == set(find_sub_classes(C))
         assert {C, D} == set(find_sub_classes(B))
         assert {C, D} == set(find_sub_classes(A))
+
+def test_find_subclasses_raises_type_error_on_non_class() -> None:
+    with pytest.raises(TypeError):
+        find_sub_classes(123)  # type: ignore[arg-type]
+
+
+def test_find_subclasses_returns_empty_list_for_class_without_subclasses() -> None:
+    class Solo:
+        pass
+
+    assert find_sub_classes(Solo, recursive=True) == []


### PR DESCRIPTION
Added TypeError check and extra tests for find_sub_classes

This PR improves the small utility find_sub_classes in class_utils.py by adding a simple input check. It now raises a TypeError if something other than a class is passed in. I also extended the existing test file with two extra cases:
1) One that confirms the function raises the new TypeError when misused
2) One that checks it returns an empty list for a class with no subclasses.
These changes don’t alter the existing behavior for valid inputs, but they make the function safer and the tests a bit more complete.