### PR TITLE
fix(sqlfmt): validate indent_count in SqlToStringFormat

### DIFF
--- a/pylegend/core/database/sql_to_string/config.py
+++ b/pylegend/core/database/sql_to_string/config.py
@@ -18,6 +18,8 @@ class SqlToStringFormat:
     indent_count: int
 
     def __init__(self, pretty: bool = True, indent_count: int = 0) -> None:
+        if indent_count < 0:
+            raise ValueError(f"indent_count must be non-negative, got: {indent_count}")
         self.pretty = pretty
         self.indent_count = indent_count
 


### PR DESCRIPTION
… (#157)

**Summary**

Fixes #157 by validating indent_count in SqlToStringFormat so negative values can’t create invalid state or odd formatting behavior (e.g., in separator() which uses range(self.indent_count + cnt)).

**Changes**

- pylegend/core/database/sql_to_string/config.py
- Validate indent_count in __init__ and raise a clear ValueError for negative inputs.

**Rationale**

- Fail fast at object creation.
- Prevents subtle bugs from negative indentation while keeping all valid usages untouched.

**Backward Compatibility**

- No behavior changes for non-negative values.
- Calling code that previously passed negatives will now raise ValueError (intended safeguard).

**Test Plan**

- Valid: 0, 1, 5, 10 → object constructs and methods behave as before.
- Invalid: -1, -10 → ValueError with helpful message.

All tests pass locally.