### PR TITLE
feat: add pylegend.cases() for multi-branch CASE expressions

### DIFF
--- a/pylegend/__init__.py
+++ b/pylegend/__init__.py
@@ -43,6 +43,7 @@ from pylegend.core.language import (
     current_user,
     olap_rank,
     olap_agg,
+    cases,
 )
 from pylegend import samples
 from pylegend.core.language import type_factory
@@ -74,6 +75,7 @@ __all__: PyLegendSequence[str] = [
     "current_user",
     "olap_rank",
     "olap_agg",
+    "cases",
 
     "samples",
     "type_factory",

--- a/pylegend/core/language/__init__.py
+++ b/pylegend/core/language/__init__.py
@@ -94,6 +94,7 @@ from pylegend.core.language.shared.functions import (
     today,
     now,
     current_user,
+    cases,
 )
 from pylegend.core.language.shared.variable_expressions import (
     PyLegendVariableExpression,
@@ -202,6 +203,7 @@ __all__: PyLegendSequence[str] = [
     "today",
     "now",
     "current_user",
+    "cases",
 
     "PyLegendVariableExpression",
     "PyLegendBooleanVariableExpression",

--- a/pylegend/core/language/shared/functions.py
+++ b/pylegend/core/language/shared/functions.py
@@ -17,8 +17,10 @@ from decimal import Decimal
 from datetime import date, datetime
 from pylegend._typing import (
     PyLegendSequence,
+    PyLegendTuple,
 )
 from pylegend.core.language.shared.expression import (
+    PyLegendExpression,
     PyLegendExpressionStringReturn,
     PyLegendExpressionBooleanReturn,
     PyLegendExpressionNumberReturn,
@@ -110,7 +112,9 @@ def previous_day_of_week(day_of_week: str) -> PyLegendStrictDate:
     return PyLegendStrictDate(PyLegendPreviousDayOfWeekExpression(validated_day))
 
 
-def cases(*when_pairs: tuple, default: PyLegendPrimitiveOrPythonPrimitive) -> PyLegendPrimitive:
+def cases(
+        *when_pairs: PyLegendTuple[PyLegendPrimitiveOrPythonPrimitive, PyLegendPrimitiveOrPythonPrimitive],
+        default: PyLegendPrimitiveOrPythonPrimitive) -> PyLegendPrimitive:
     """
     Multi-branch conditional — SQL ``CASE WHEN … THEN … ELSE … END``.
 
@@ -171,7 +175,7 @@ def cases(*when_pairs: tuple, default: PyLegendPrimitiveOrPythonPrimitive) -> Py
     if not when_pairs:
         raise TypeError("cases() requires at least one (condition, value) pair.")
 
-    def resolve_value(param: PyLegendPrimitiveOrPythonPrimitive, label: str):  # type: ignore[no-untyped-def]
+    def resolve_value(param: PyLegendPrimitiveOrPythonPrimitive, label: str) -> "PyLegendExpression":
         if isinstance(param, (bool, int, float, str, date, datetime, Decimal)):
             return convert_literal_to_literal_expression(param)
         elif isinstance(param, PyLegendPrimitive):
@@ -216,23 +220,24 @@ def cases(*when_pairs: tuple, default: PyLegendPrimitiveOrPythonPrimitive) -> Py
         return all(isinstance(e, cls) for e in all_result_exprs)
 
     if all_match(PyLegendExpressionBooleanReturn):
-        return PyLegendBoolean(PyLegendBooleanMultiCaseExpression(resolved_pairs, default_expr))
+        return PyLegendBoolean(PyLegendBooleanMultiCaseExpression(resolved_pairs, default_expr))  # type: ignore[arg-type]
     elif all_match(PyLegendExpressionStringReturn):
-        return PyLegendString(PyLegendStringMultiCaseExpression(resolved_pairs, default_expr))
+        return PyLegendString(PyLegendStringMultiCaseExpression(resolved_pairs, default_expr))  # type: ignore[arg-type]
     elif all_match(PyLegendExpressionDateTimeReturn):
-        return PyLegendDateTime(PyLegendDateTimeMultiCaseExpression(resolved_pairs, default_expr))
+        return PyLegendDateTime(PyLegendDateTimeMultiCaseExpression(resolved_pairs, default_expr))  # type: ignore[arg-type]
     elif all_match(PyLegendExpressionStrictDateReturn):
-        return PyLegendStrictDate(PyLegendStrictDateMultiCaseExpression(resolved_pairs, default_expr))
+        expr = PyLegendStrictDateMultiCaseExpression(resolved_pairs, default_expr)  # type: ignore[arg-type]
+        return PyLegendStrictDate(expr)
     elif all_match(PyLegendExpressionDateReturn):
-        return PyLegendDate(PyLegendDateMultiCaseExpression(resolved_pairs, default_expr))
+        return PyLegendDate(PyLegendDateMultiCaseExpression(resolved_pairs, default_expr))  # type: ignore[arg-type]
     elif all_match(PyLegendExpressionDecimalReturn):
-        return PyLegendDecimal(PyLegendDecimalMultiCaseExpression(resolved_pairs, default_expr))
+        return PyLegendDecimal(PyLegendDecimalMultiCaseExpression(resolved_pairs, default_expr))  # type: ignore[arg-type]
     elif all_match(PyLegendExpressionFloatReturn):
-        return PyLegendFloat(PyLegendFloatMultiCaseExpression(resolved_pairs, default_expr))
+        return PyLegendFloat(PyLegendFloatMultiCaseExpression(resolved_pairs, default_expr))  # type: ignore[arg-type]
     elif all_match(PyLegendExpressionIntegerReturn):
-        return PyLegendInteger(PyLegendIntegerMultiCaseExpression(resolved_pairs, default_expr))
+        return PyLegendInteger(PyLegendIntegerMultiCaseExpression(resolved_pairs, default_expr))  # type: ignore[arg-type]
     elif all_match(PyLegendExpressionNumberReturn):
-        return PyLegendNumber(PyLegendNumberMultiCaseExpression(resolved_pairs, default_expr))
+        return PyLegendNumber(PyLegendNumberMultiCaseExpression(resolved_pairs, default_expr))  # type: ignore[arg-type]
     else:
         raise TypeError(
             "cases() all value branches (including default) must belong to the same type family."

--- a/pylegend/core/language/shared/functions.py
+++ b/pylegend/core/language/shared/functions.py
@@ -13,14 +13,30 @@
 # limitations under the License.
 
 
+from decimal import Decimal
+from datetime import date, datetime
 from pylegend._typing import (
     PyLegendSequence,
 )
-from pylegend.core.language.shared.expression import PyLegendExpressionStringReturn
-from pylegend.core.language.shared.literal_expressions import PyLegendStringLiteralExpression
+from pylegend.core.language.shared.expression import (
+    PyLegendExpressionStringReturn,
+    PyLegendExpressionBooleanReturn,
+    PyLegendExpressionNumberReturn,
+    PyLegendExpressionIntegerReturn,
+    PyLegendExpressionFloatReturn,
+    PyLegendExpressionDecimalReturn,
+    PyLegendExpressionDateReturn,
+    PyLegendExpressionDateTimeReturn,
+    PyLegendExpressionStrictDateReturn,
+)
+from pylegend.core.language.shared.literal_expressions import (
+    PyLegendStringLiteralExpression,
+    convert_literal_to_literal_expression,
+)
 from pylegend.core.language.shared.primitives.strictdate import PyLegendStrictDate
 from pylegend.core.language.shared.primitives.datetime import PyLegendDateTime
 from pylegend.core.language.shared.primitives.string import PyLegendString
+from pylegend.core.language.shared.primitives.primitive import PyLegendPrimitive, PyLegendPrimitiveOrPythonPrimitive
 from pylegend.core.language.shared.operations.date_operation_expressions import (
     PyLegendTodayExpression,
     PyLegendNowExpression,
@@ -32,6 +48,17 @@ from pylegend.core.language.shared.operations.string_operation_expressions impor
 )
 from pylegend.core.language.shared.primitives.float import PyLegendFloat
 from pylegend.core.language.shared.operations.float_operation_expressions import PyLegendFloatPiExpression
+from pylegend.core.language.shared.operations.boolean_operation_expressions import (
+    PyLegendBooleanMultiCaseExpression,
+    PyLegendStringMultiCaseExpression,
+    PyLegendNumberMultiCaseExpression,
+    PyLegendIntegerMultiCaseExpression,
+    PyLegendFloatMultiCaseExpression,
+    PyLegendDecimalMultiCaseExpression,
+    PyLegendDateMultiCaseExpression,
+    PyLegendDateTimeMultiCaseExpression,
+    PyLegendStrictDateMultiCaseExpression,
+)
 
 
 __all__: PyLegendSequence[str] = [
@@ -41,6 +68,7 @@ __all__: PyLegendSequence[str] = [
     "pi",
     "most_recent_day_of_week",
     "previous_day_of_week",
+    "cases",
 ]
 
 
@@ -80,3 +108,133 @@ def most_recent_day_of_week(day_of_week: str) -> PyLegendStrictDate:
 def previous_day_of_week(day_of_week: str) -> PyLegendStrictDate:
     validated_day = _validate_day_of_week(day_of_week)
     return PyLegendStrictDate(PyLegendPreviousDayOfWeekExpression(validated_day))
+
+
+def cases(*when_pairs: tuple, default: PyLegendPrimitiveOrPythonPrimitive) -> PyLegendPrimitive:
+    """
+    Multi-branch conditional — SQL ``CASE WHEN … THEN … ELSE … END``.
+
+    Build an N-branch CASE expression from a sequence of
+    ``(condition, value)`` pairs and a required default value.  Each
+    *condition* must be a boolean expression; all *value* arguments
+    (including *default*) must belong to the same type family.
+
+    Parameters
+    ----------
+    *when_pairs : tuple of (condition, value)
+        One or more ``(PyLegendBoolean, value)`` pairs evaluated in
+        order.  The first pair whose condition is ``True`` determines
+        the result.  At least one pair is required.
+    default : int, float, bool, str, date, datetime, Decimal, or PyLegendPrimitive
+        Value returned when no condition matches.
+
+    Returns
+    -------
+    PyLegendPrimitive
+        An expression whose concrete type is inferred from the value
+        branches (e.g. ``PyLegendString`` when all values are strings).
+        Mixed numeric branches widen to ``PyLegendNumber``.
+
+    Raises
+    ------
+    TypeError
+        If no pairs are supplied, a pair is not a 2-tuple, a condition
+        is not boolean, a value is not a supported primitive type, or
+        the values have incompatible types.
+
+    Examples
+    --------
+    .. ipython:: python
+
+        import pylegend
+        frame = pylegend.samples.legendql_api.northwind_frame()
+
+        frame = frame.extend(("Category", lambda r: pylegend.cases(
+            (r.get_integer("Order Id") < 10250, "small"),
+            (r.get_integer("Order Id") < 10260, "medium"),
+            default="large",
+        )))
+
+    """
+    from pylegend.core.language.shared.primitives import (
+        PyLegendBoolean,
+        PyLegendString,
+        PyLegendNumber,
+        PyLegendInteger,
+        PyLegendFloat,
+        PyLegendDecimal,
+        PyLegendDate,
+        PyLegendDateTime,
+        PyLegendStrictDate,
+    )
+
+    if not when_pairs:
+        raise TypeError("cases() requires at least one (condition, value) pair.")
+
+    def resolve_value(param: PyLegendPrimitiveOrPythonPrimitive, label: str):  # type: ignore[no-untyped-def]
+        if isinstance(param, (bool, int, float, str, date, datetime, Decimal)):
+            return convert_literal_to_literal_expression(param)
+        elif isinstance(param, PyLegendPrimitive):
+            return param.value()
+        else:
+            raise TypeError(
+                f"cases() {label} should be a primitive value or PyLegendPrimitive expression."
+                f" Got value {param} of type: {type(param)}"
+            )
+
+    resolved_pairs = []
+    for i, pair in enumerate(when_pairs):
+        if not (isinstance(pair, tuple) and len(pair) == 2):
+            raise TypeError(
+                f"cases() when_pairs[{i}] must be a 2-tuple (condition, value)."
+                f" Got: {pair!r}"
+            )
+        cond, val = pair
+        if isinstance(cond, PyLegendBoolean):
+            cond_expr = cond.value()
+        elif isinstance(cond, PyLegendPrimitive):
+            expr = cond.value()
+            if not isinstance(expr, PyLegendExpressionBooleanReturn):
+                raise TypeError(
+                    f"cases() condition at index {i} must be a boolean expression."
+                    f" Got: {type(cond)}"
+                )
+            cond_expr = expr
+        else:
+            raise TypeError(
+                f"cases() condition at index {i} must be a PyLegendBoolean expression."
+                f" Got: {type(cond)}"
+            )
+        val_expr = resolve_value(val, f"value at index {i}")
+        resolved_pairs.append((cond_expr, val_expr))
+
+    default_expr = resolve_value(default, "default")
+
+    all_result_exprs = [val for _, val in resolved_pairs] + [default_expr]
+
+    def all_match(cls: type) -> bool:
+        return all(isinstance(e, cls) for e in all_result_exprs)
+
+    if all_match(PyLegendExpressionBooleanReturn):
+        return PyLegendBoolean(PyLegendBooleanMultiCaseExpression(resolved_pairs, default_expr))
+    elif all_match(PyLegendExpressionStringReturn):
+        return PyLegendString(PyLegendStringMultiCaseExpression(resolved_pairs, default_expr))
+    elif all_match(PyLegendExpressionDateTimeReturn):
+        return PyLegendDateTime(PyLegendDateTimeMultiCaseExpression(resolved_pairs, default_expr))
+    elif all_match(PyLegendExpressionStrictDateReturn):
+        return PyLegendStrictDate(PyLegendStrictDateMultiCaseExpression(resolved_pairs, default_expr))
+    elif all_match(PyLegendExpressionDateReturn):
+        return PyLegendDate(PyLegendDateMultiCaseExpression(resolved_pairs, default_expr))
+    elif all_match(PyLegendExpressionDecimalReturn):
+        return PyLegendDecimal(PyLegendDecimalMultiCaseExpression(resolved_pairs, default_expr))
+    elif all_match(PyLegendExpressionFloatReturn):
+        return PyLegendFloat(PyLegendFloatMultiCaseExpression(resolved_pairs, default_expr))
+    elif all_match(PyLegendExpressionIntegerReturn):
+        return PyLegendInteger(PyLegendIntegerMultiCaseExpression(resolved_pairs, default_expr))
+    elif all_match(PyLegendExpressionNumberReturn):
+        return PyLegendNumber(PyLegendNumberMultiCaseExpression(resolved_pairs, default_expr))
+    else:
+        raise TypeError(
+            "cases() all value branches (including default) must belong to the same type family."
+            " Supported families: bool, int, float, Decimal, str, date, datetime, PyLegendPrimitive"
+        )

--- a/pylegend/core/language/shared/operations/boolean_operation_expressions.py
+++ b/pylegend/core/language/shared/operations/boolean_operation_expressions.py
@@ -15,6 +15,7 @@
 from pylegend._typing import (
     PyLegendSequence,
     PyLegendDict,
+    PyLegendList,
 )
 from pylegend.core.language.shared.expression import (
     PyLegendExpression,
@@ -65,6 +66,15 @@ __all__: PyLegendSequence[str] = [
     "PyLegendDateCaseExpression",
     "PyLegendDateTimeCaseExpression",
     "PyLegendStrictDateCaseExpression",
+    "PyLegendBooleanMultiCaseExpression",
+    "PyLegendStringMultiCaseExpression",
+    "PyLegendNumberMultiCaseExpression",
+    "PyLegendIntegerMultiCaseExpression",
+    "PyLegendFloatMultiCaseExpression",
+    "PyLegendDecimalMultiCaseExpression",
+    "PyLegendDateMultiCaseExpression",
+    "PyLegendDateTimeMultiCaseExpression",
+    "PyLegendStrictDateMultiCaseExpression",
 ]
 
 
@@ -383,3 +393,104 @@ class PyLegendStrictDateCaseExpression(PyLegendCaseExpressionBase, PyLegendExpre
                  if_true: PyLegendExpressionStrictDateReturn, if_false: PyLegendExpressionStrictDateReturn) -> None:
         PyLegendExpressionStrictDateReturn.__init__(self)
         PyLegendCaseExpressionBase.__init__(self, condition, if_true, if_false)
+
+
+class PyLegendMultiCaseExpressionBase(PyLegendNaryExpression):
+
+    @staticmethod
+    def __to_sql_func(
+            expressions: list[Expression],
+            frame_name_to_base_query_map: PyLegendDict[str, QuerySpecification],
+            config: FrameToSqlConfig
+    ) -> Expression:
+        n = (len(expressions) - 1) // 2
+        when_clauses = [
+            WhenClause(operand=expressions[2 * i], result=expressions[2 * i + 1])
+            for i in range(n)
+        ]
+        return SearchedCaseExpression(whenClauses=when_clauses, defaultValue=expressions[-1])
+
+    @staticmethod
+    def __to_pure_func(op_exprs: list[str], config: FrameToPureConfig) -> str:
+        n = (len(op_exprs) - 1) // 2
+        acc = op_exprs[-1]
+        for i in range(n - 1, -1, -1):
+            acc = f"if({op_exprs[2 * i]}, |{op_exprs[2 * i + 1]}, |{acc})"
+        return acc
+
+    def __init__(
+            self,
+            when_pairs: PyLegendList[tuple],
+            default: PyLegendExpression,
+    ) -> None:
+        operands: PyLegendList[PyLegendExpression] = []
+        non_nullable_flags: PyLegendList[bool] = []
+        for condition, result in when_pairs:
+            operands.append(condition)
+            non_nullable_flags.append(True)
+            operands.append(result)
+            non_nullable_flags.append(False)
+        operands.append(default)
+        non_nullable_flags.append(False)
+        PyLegendNaryExpression.__init__(
+            self,
+            operands,
+            PyLegendMultiCaseExpressionBase.__to_sql_func,
+            PyLegendMultiCaseExpressionBase.__to_pure_func,
+            non_nullable=False,
+            operands_non_nullable_flags=non_nullable_flags,
+        )
+
+
+class PyLegendBooleanMultiCaseExpression(PyLegendMultiCaseExpressionBase, PyLegendExpressionBooleanReturn):
+    def __init__(self, when_pairs: PyLegendList[tuple], default: PyLegendExpressionBooleanReturn) -> None:
+        PyLegendExpressionBooleanReturn.__init__(self)
+        PyLegendMultiCaseExpressionBase.__init__(self, when_pairs, default)
+
+
+class PyLegendStringMultiCaseExpression(PyLegendMultiCaseExpressionBase, PyLegendExpressionStringReturn):
+    def __init__(self, when_pairs: PyLegendList[tuple], default: PyLegendExpressionStringReturn) -> None:
+        PyLegendExpressionStringReturn.__init__(self)
+        PyLegendMultiCaseExpressionBase.__init__(self, when_pairs, default)
+
+
+class PyLegendNumberMultiCaseExpression(PyLegendMultiCaseExpressionBase, PyLegendExpressionNumberReturn):
+    def __init__(self, when_pairs: PyLegendList[tuple], default: PyLegendExpressionNumberReturn) -> None:
+        PyLegendExpressionNumberReturn.__init__(self)
+        PyLegendMultiCaseExpressionBase.__init__(self, when_pairs, default)
+
+
+class PyLegendIntegerMultiCaseExpression(PyLegendMultiCaseExpressionBase, PyLegendExpressionIntegerReturn):
+    def __init__(self, when_pairs: PyLegendList[tuple], default: PyLegendExpressionIntegerReturn) -> None:
+        PyLegendExpressionIntegerReturn.__init__(self)
+        PyLegendMultiCaseExpressionBase.__init__(self, when_pairs, default)
+
+
+class PyLegendFloatMultiCaseExpression(PyLegendMultiCaseExpressionBase, PyLegendExpressionFloatReturn):
+    def __init__(self, when_pairs: PyLegendList[tuple], default: PyLegendExpressionFloatReturn) -> None:
+        PyLegendExpressionFloatReturn.__init__(self)
+        PyLegendMultiCaseExpressionBase.__init__(self, when_pairs, default)
+
+
+class PyLegendDecimalMultiCaseExpression(PyLegendMultiCaseExpressionBase, PyLegendExpressionDecimalReturn):
+    def __init__(self, when_pairs: PyLegendList[tuple], default: PyLegendExpressionDecimalReturn) -> None:
+        PyLegendExpressionDecimalReturn.__init__(self)
+        PyLegendMultiCaseExpressionBase.__init__(self, when_pairs, default)
+
+
+class PyLegendDateMultiCaseExpression(PyLegendMultiCaseExpressionBase, PyLegendExpressionDateReturn):
+    def __init__(self, when_pairs: PyLegendList[tuple], default: PyLegendExpressionDateReturn) -> None:
+        PyLegendExpressionDateReturn.__init__(self)
+        PyLegendMultiCaseExpressionBase.__init__(self, when_pairs, default)
+
+
+class PyLegendDateTimeMultiCaseExpression(PyLegendMultiCaseExpressionBase, PyLegendExpressionDateTimeReturn):
+    def __init__(self, when_pairs: PyLegendList[tuple], default: PyLegendExpressionDateTimeReturn) -> None:
+        PyLegendExpressionDateTimeReturn.__init__(self)
+        PyLegendMultiCaseExpressionBase.__init__(self, when_pairs, default)
+
+
+class PyLegendStrictDateMultiCaseExpression(PyLegendMultiCaseExpressionBase, PyLegendExpressionStrictDateReturn):
+    def __init__(self, when_pairs: PyLegendList[tuple], default: PyLegendExpressionStrictDateReturn) -> None:
+        PyLegendExpressionStrictDateReturn.__init__(self)
+        PyLegendMultiCaseExpressionBase.__init__(self, when_pairs, default)

--- a/pylegend/core/language/shared/operations/boolean_operation_expressions.py
+++ b/pylegend/core/language/shared/operations/boolean_operation_expressions.py
@@ -16,6 +16,7 @@ from pylegend._typing import (
     PyLegendSequence,
     PyLegendDict,
     PyLegendList,
+    PyLegendTuple,
 )
 from pylegend.core.language.shared.expression import (
     PyLegendExpression,
@@ -420,7 +421,7 @@ class PyLegendMultiCaseExpressionBase(PyLegendNaryExpression):
 
     def __init__(
             self,
-            when_pairs: PyLegendList[tuple],
+            when_pairs: "_WhenPairs",
             default: PyLegendExpression,
     ) -> None:
         operands: PyLegendList[PyLegendExpression] = []
@@ -442,55 +443,58 @@ class PyLegendMultiCaseExpressionBase(PyLegendNaryExpression):
         )
 
 
+_WhenPairs = PyLegendList[PyLegendTuple[PyLegendExpressionBooleanReturn, PyLegendExpression]]
+
+
 class PyLegendBooleanMultiCaseExpression(PyLegendMultiCaseExpressionBase, PyLegendExpressionBooleanReturn):
-    def __init__(self, when_pairs: PyLegendList[tuple], default: PyLegendExpressionBooleanReturn) -> None:
+    def __init__(self, when_pairs: _WhenPairs, default: PyLegendExpressionBooleanReturn) -> None:
         PyLegendExpressionBooleanReturn.__init__(self)
         PyLegendMultiCaseExpressionBase.__init__(self, when_pairs, default)
 
 
 class PyLegendStringMultiCaseExpression(PyLegendMultiCaseExpressionBase, PyLegendExpressionStringReturn):
-    def __init__(self, when_pairs: PyLegendList[tuple], default: PyLegendExpressionStringReturn) -> None:
+    def __init__(self, when_pairs: _WhenPairs, default: PyLegendExpressionStringReturn) -> None:
         PyLegendExpressionStringReturn.__init__(self)
         PyLegendMultiCaseExpressionBase.__init__(self, when_pairs, default)
 
 
 class PyLegendNumberMultiCaseExpression(PyLegendMultiCaseExpressionBase, PyLegendExpressionNumberReturn):
-    def __init__(self, when_pairs: PyLegendList[tuple], default: PyLegendExpressionNumberReturn) -> None:
+    def __init__(self, when_pairs: _WhenPairs, default: PyLegendExpressionNumberReturn) -> None:
         PyLegendExpressionNumberReturn.__init__(self)
         PyLegendMultiCaseExpressionBase.__init__(self, when_pairs, default)
 
 
 class PyLegendIntegerMultiCaseExpression(PyLegendMultiCaseExpressionBase, PyLegendExpressionIntegerReturn):
-    def __init__(self, when_pairs: PyLegendList[tuple], default: PyLegendExpressionIntegerReturn) -> None:
+    def __init__(self, when_pairs: _WhenPairs, default: PyLegendExpressionIntegerReturn) -> None:
         PyLegendExpressionIntegerReturn.__init__(self)
         PyLegendMultiCaseExpressionBase.__init__(self, when_pairs, default)
 
 
 class PyLegendFloatMultiCaseExpression(PyLegendMultiCaseExpressionBase, PyLegendExpressionFloatReturn):
-    def __init__(self, when_pairs: PyLegendList[tuple], default: PyLegendExpressionFloatReturn) -> None:
+    def __init__(self, when_pairs: _WhenPairs, default: PyLegendExpressionFloatReturn) -> None:
         PyLegendExpressionFloatReturn.__init__(self)
         PyLegendMultiCaseExpressionBase.__init__(self, when_pairs, default)
 
 
 class PyLegendDecimalMultiCaseExpression(PyLegendMultiCaseExpressionBase, PyLegendExpressionDecimalReturn):
-    def __init__(self, when_pairs: PyLegendList[tuple], default: PyLegendExpressionDecimalReturn) -> None:
+    def __init__(self, when_pairs: _WhenPairs, default: PyLegendExpressionDecimalReturn) -> None:
         PyLegendExpressionDecimalReturn.__init__(self)
         PyLegendMultiCaseExpressionBase.__init__(self, when_pairs, default)
 
 
 class PyLegendDateMultiCaseExpression(PyLegendMultiCaseExpressionBase, PyLegendExpressionDateReturn):
-    def __init__(self, when_pairs: PyLegendList[tuple], default: PyLegendExpressionDateReturn) -> None:
+    def __init__(self, when_pairs: _WhenPairs, default: PyLegendExpressionDateReturn) -> None:
         PyLegendExpressionDateReturn.__init__(self)
         PyLegendMultiCaseExpressionBase.__init__(self, when_pairs, default)
 
 
 class PyLegendDateTimeMultiCaseExpression(PyLegendMultiCaseExpressionBase, PyLegendExpressionDateTimeReturn):
-    def __init__(self, when_pairs: PyLegendList[tuple], default: PyLegendExpressionDateTimeReturn) -> None:
+    def __init__(self, when_pairs: _WhenPairs, default: PyLegendExpressionDateTimeReturn) -> None:
         PyLegendExpressionDateTimeReturn.__init__(self)
         PyLegendMultiCaseExpressionBase.__init__(self, when_pairs, default)
 
 
 class PyLegendStrictDateMultiCaseExpression(PyLegendMultiCaseExpressionBase, PyLegendExpressionStrictDateReturn):
-    def __init__(self, when_pairs: PyLegendList[tuple], default: PyLegendExpressionStrictDateReturn) -> None:
+    def __init__(self, when_pairs: _WhenPairs, default: PyLegendExpressionStrictDateReturn) -> None:
         PyLegendExpressionStrictDateReturn.__init__(self)
         PyLegendMultiCaseExpressionBase.__init__(self, when_pairs, default)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pylegend"
-version = "1.1.1"
+version = "1.1.2"
 description = "Python language binding for Legend data management platform"
 authors = [{ name = "PyLegend Maintainers", email = "legend@finos.org" }]
 requires-python = ">=3.9,<3.15"

--- a/tests/core/language/shared/test_functions.py
+++ b/tests/core/language/shared/test_functions.py
@@ -13,9 +13,8 @@
 # limitations under the License.
 
 import pytest
-from datetime import date, datetime
-from decimal import Decimal
-from pylegend._typing import PyLegendCallable, PyLegendDict, PyLegendUnion
+from datetime import date
+from pylegend._typing import PyLegendDict, PyLegendUnion
 from pylegend.core.database.sql_to_string import (
     SqlToStringFormat,
     SqlToStringConfig,
@@ -135,7 +134,7 @@ class TestCasesFunction:
 
     def test_cases_no_pairs_raises(self) -> None:
         with pytest.raises(TypeError, match="at least one"):
-            pylegend.cases(default="x")  # type: ignore[call-arg]
+            pylegend.cases(default="x")
 
     def test_cases_non_tuple_pair_raises(self) -> None:
         with pytest.raises(TypeError, match="2-tuple"):
@@ -144,7 +143,7 @@ class TestCasesFunction:
     def test_cases_non_boolean_condition_raises(self) -> None:
         with pytest.raises(TypeError, match="boolean expression"):
             pylegend.cases(
-                (self.tds_row.get_string("s1"), "Rule1"),  # type: ignore[arg-type]
+                (self.tds_row.get_string("s1"), "Rule1"),
                 default="Default",
             )
 
@@ -175,14 +174,15 @@ class TestCasesFunction:
 
     def __pure_str(self, expr: PyLegendPrimitive) -> str:
         result = str(expr.to_pure_expression(self.frame_to_pure_config))
-        model_code = """
-        function test::testFunc(): Any[*]
-        {
-            []->toOne()->cast(
-                @meta::pure::metamodel::relation::Relation<(b1: Boolean[0..1], b2: Boolean[0..1], b3: Boolean[0..1], s1: String[0..1], i1: Integer[0..1])>
-            )
-            ->extend(~new_col:t|<<expression>>)
-        }
-        """
+        model_code = (
+            "function test::testFunc(): Any[*]\n"
+            "{\n"
+            "    []->toOne()->cast(\n"
+            "        @meta::pure::metamodel::relation::Relation"
+            "<(b1: Boolean[0..1], b2: Boolean[0..1], b3: Boolean[0..1])>\n"
+            "    )\n"
+            "    ->extend(~new_col:t|<<expression>>)\n"
+            "}"
+        )
         self.__legend_client.parse_and_compile_model(model_code.replace("<<expression>>", result))
         return result

--- a/tests/core/language/shared/test_functions.py
+++ b/tests/core/language/shared/test_functions.py
@@ -1,0 +1,188 @@
+# Copyright 2025 Goldman Sachs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from datetime import date, datetime
+from decimal import Decimal
+from pylegend._typing import PyLegendCallable, PyLegendDict, PyLegendUnion
+from pylegend.core.database.sql_to_string import (
+    SqlToStringFormat,
+    SqlToStringConfig,
+    SqlToStringDbExtension,
+)
+from pylegend.core.tds.tds_frame import FrameToSqlConfig, FrameToPureConfig
+from pylegend.core.tds.tds_column import PrimitiveTdsColumn
+from pylegend.core.language import PyLegendPrimitive
+from pylegend.core.request.legend_client import LegendClient
+from tests.core.language.shared import TestTableSpecInputFrame, TestTdsRow
+import pylegend
+
+
+class TestCasesFunction:
+    frame_to_sql_config = FrameToSqlConfig()
+    frame_to_pure_config = FrameToPureConfig()
+    db_extension = SqlToStringDbExtension()
+    sql_to_string_config = SqlToStringConfig(SqlToStringFormat(pretty=True))
+
+    test_frame = TestTableSpecInputFrame(['test_schema', 'test_table'], [
+        PrimitiveTdsColumn.boolean_column("b1"),
+        PrimitiveTdsColumn.boolean_column("b2"),
+        PrimitiveTdsColumn.boolean_column("b3"),
+        PrimitiveTdsColumn.string_column("s1"),
+        PrimitiveTdsColumn.integer_column("i1"),
+    ])
+    tds_row = TestTdsRow.from_tds_frame("t", test_frame)
+    base_query = test_frame.to_sql_query_object(frame_to_sql_config)
+
+    @pytest.fixture(autouse=True)
+    def init_legend(self, legend_test_server: PyLegendDict[str, PyLegendUnion[int,]]) -> None:
+        self.__legend_client = LegendClient("localhost", legend_test_server["engine_port"], secure_http=False)
+
+    # ------------------------------------------------------------------
+    # String branches
+    # ------------------------------------------------------------------
+
+    def test_cases_string_pure(self) -> None:
+        expr = pylegend.cases(
+            (self.tds_row.get_boolean("b1"), "Rule1"),
+            (self.tds_row.get_boolean("b2"), "Rule2"),
+            (self.tds_row.get_boolean("b3"), "Rule3"),
+            default="Default",
+        )
+        assert self.__pure_str(expr) == "if(toOne($t.b1), |'Rule1', |if(toOne($t.b2), |'Rule2', |if(toOne($t.b3), |'Rule3', |'Default')))"  # noqa: E501
+
+    def test_cases_string_sql(self) -> None:
+        expr = pylegend.cases(
+            (self.tds_row.get_boolean("b1"), "Rule1"),
+            (self.tds_row.get_boolean("b2"), "Rule2"),
+            default="Default",
+        )
+        assert self.__sql_str(expr) == (
+            "CASE\n"
+            "    WHEN\n        \"root\".b1\n    THEN\n        'Rule1'\n"
+            "    WHEN\n        \"root\".b2\n    THEN\n        'Rule2'\n"
+            "    ELSE\n        'Default'\n"
+            "END"
+        )
+
+    # ------------------------------------------------------------------
+    # Integer branches
+    # ------------------------------------------------------------------
+
+    def test_cases_integer_pure(self) -> None:
+        expr = pylegend.cases(
+            (self.tds_row.get_boolean("b1"), 1),
+            (self.tds_row.get_boolean("b2"), 2),
+            default=0,
+        )
+        assert self.__pure_str(expr) == "if(toOne($t.b1), |1, |if(toOne($t.b2), |2, |0))"
+
+    # ------------------------------------------------------------------
+    # Single pair (degenerate case)
+    # ------------------------------------------------------------------
+
+    def test_cases_single_pair(self) -> None:
+        expr = pylegend.cases(
+            (self.tds_row.get_boolean("b1"), "yes"),
+            default="no",
+        )
+        assert self.__pure_str(expr) == "if(toOne($t.b1), |'yes', |'no')"
+
+    # ------------------------------------------------------------------
+    # Date branch
+    # ------------------------------------------------------------------
+
+    def test_cases_date_pure(self) -> None:
+        expr = pylegend.cases(
+            (self.tds_row.get_boolean("b1"), date(2025, 1, 1)),
+            (self.tds_row.get_boolean("b2"), date(2025, 6, 1)),
+            default=date(2025, 12, 31),
+        )
+        assert self.__pure_str(expr) == (
+            "if(toOne($t.b1), |%2025-01-01, |if(toOne($t.b2), |%2025-06-01, |%2025-12-31))"
+        )
+
+    # ------------------------------------------------------------------
+    # Numeric widening: Number col + int literal -> Number
+    # ------------------------------------------------------------------
+
+    def test_cases_numeric_widening_to_number(self) -> None:
+        number_frame = TestTableSpecInputFrame(['test_schema', 'test_table'], [
+            PrimitiveTdsColumn.number_column("num_col"),
+            PrimitiveTdsColumn.boolean_column("bool_col"),
+        ])
+        number_row = TestTdsRow.from_tds_frame("t", number_frame)
+        expr = pylegend.cases(
+            (number_row.get_boolean("bool_col"), number_row.get_number("num_col")),
+            default=0,
+        )
+        assert str(expr.to_pure_expression(self.frame_to_pure_config)) == "if(toOne($t.bool_col), |$t.num_col, |0)"
+
+    # ------------------------------------------------------------------
+    # Error paths
+    # ------------------------------------------------------------------
+
+    def test_cases_no_pairs_raises(self) -> None:
+        with pytest.raises(TypeError, match="at least one"):
+            pylegend.cases(default="x")  # type: ignore[call-arg]
+
+    def test_cases_non_tuple_pair_raises(self) -> None:
+        with pytest.raises(TypeError, match="2-tuple"):
+            pylegend.cases("not_a_tuple", default="x")  # type: ignore[arg-type]
+
+    def test_cases_non_boolean_condition_raises(self) -> None:
+        with pytest.raises(TypeError, match="boolean expression"):
+            pylegend.cases(
+                (self.tds_row.get_string("s1"), "Rule1"),  # type: ignore[arg-type]
+                default="Default",
+            )
+
+    def test_cases_mismatched_types_raises(self) -> None:
+        with pytest.raises(TypeError, match="same type family"):
+            pylegend.cases(
+                (self.tds_row.get_boolean("b1"), "string_val"),
+                (self.tds_row.get_boolean("b2"), 999),
+                default="Default",
+            )
+
+    def test_cases_invalid_value_raises(self) -> None:
+        with pytest.raises(TypeError, match="primitive value"):
+            pylegend.cases(
+                (self.tds_row.get_boolean("b1"), [1, 2]),  # type: ignore[arg-type]
+                default="Default",
+            )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def __sql_str(self, expr: PyLegendPrimitive) -> str:
+        return self.db_extension.process_expression(
+            expr.to_sql_expression({"t": self.base_query}, self.frame_to_sql_config),
+            config=self.sql_to_string_config,
+        )
+
+    def __pure_str(self, expr: PyLegendPrimitive) -> str:
+        result = str(expr.to_pure_expression(self.frame_to_pure_config))
+        model_code = """
+        function test::testFunc(): Any[*]
+        {
+            []->toOne()->cast(
+                @meta::pure::metamodel::relation::Relation<(b1: Boolean[0..1], b2: Boolean[0..1], b3: Boolean[0..1], s1: String[0..1], i1: Integer[0..1])>
+            )
+            ->extend(~new_col:t|<<expression>>)
+        }
+        """
+        self.__legend_client.parse_and_compile_model(model_code.replace("<<expression>>", result))
+        return result

--- a/tests/core/tds/legendql_api/frames/functions/test_legendql_api_extend_function.py
+++ b/tests/core/tds/legendql_api/frames/functions/test_legendql_api_extend_function.py
@@ -15,6 +15,7 @@
 import json
 import pytest
 from textwrap import dedent
+import pylegend
 from pylegend.core.tds.tds_column import PrimitiveTdsColumn
 from pylegend.core.tds.tds_frame import FrameToSqlConfig
 from pylegend.core.tds.tds_frame import FrameToPureConfig
@@ -428,6 +429,29 @@ class TestExtendAppliedFunction:
                              {'values': ['Harris', 1, 2.0, 'Hello', True]}]}
         res = frame.execute_frame_to_string()
         assert json.loads(res)["result"] == expected
+
+    def test_query_gen_extend_function_cases(self) -> None:
+        columns = [
+            PrimitiveTdsColumn.string_column("attributes"),
+        ]
+        frame: LegendQLApiTdsFrame = LegendQLApiTableSpecInputFrame(['test_schema', 'test_table'], columns)
+        frame = frame.extend(
+            ("rule", lambda r: pylegend.cases(
+                (r.get_string("attributes") == "OPTION1", "Rule1"),
+                (r.get_string("attributes") == "OPTION2", "Rule2"),
+                (r.get_string("attributes") == "OPTION3", "Rule3"),
+                default="Default",
+            ))
+        )
+        assert generate_pure_query_and_compile(frame, FrameToPureConfig(), self.legend_client) == dedent(
+            '''\
+            #Table(test_schema.test_table)#
+              ->extend(~rule:{r | if(($r.attributes == 'OPTION1'), |'Rule1', |if(($r.attributes == 'OPTION2'), |'Rule2', |if(($r.attributes == 'OPTION3'), |'Rule3', |'Default')))})'''  # noqa: E501
+        )
+        assert generate_pure_query_and_compile(frame, FrameToPureConfig(pretty=False), self.legend_client) == (
+            "#Table(test_schema.test_table)#->extend(~rule:{r | if(($r.attributes == 'OPTION1'), |'Rule1', "
+            "|if(($r.attributes == 'OPTION2'), |'Rule2', |if(($r.attributes == 'OPTION3'), |'Rule3', |'Default')))})"
+        )
 
     @pytest.mark.skip(reason="Server does not handle window functions of this form yet")
     def test_e2e_extend_function_with_agg(self, legend_test_server: PyLegendDict[str, PyLegendUnion[int, ]]) -> None:


### PR DESCRIPTION
Adds a top-level free function `pylegend.cases(*when_pairs, default=)` that generates N-branch SQL CASE / Pure nested-if expressions, usable inside LegendQL extend/project lambdas. Complements the existing single-branch `.case()` method on PyLegendBoolean.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>