### PR TITLE
feat: add Time, Variant, and Binary primitive types (Issue #220)

### DIFF
--- a/pylegend/core/language/shared/column_expressions.py
+++ b/pylegend/core/language/shared/column_expressions.py
@@ -29,6 +29,7 @@ from pylegend.core.language.shared.expression import (
     PyLegendExpressionDateReturn,
     PyLegendExpressionDateTimeReturn,
     PyLegendExpressionStrictDateReturn,
+    PyLegendExpressionTimeReturn,
 )
 from pylegend.core.sql.metamodel import (
     Expression,
@@ -53,6 +54,9 @@ __all__: PyLegendSequence[str] = [
     "PyLegendDateColumnExpression",
     "PyLegendDateTimeColumnExpression",
     "PyLegendStrictDateColumnExpression",
+    "PyLegendTimeColumnExpression",
+    "PyLegendVariantColumnExpression",
+    "PyLegendBinaryColumnExpression",
 ]
 
 
@@ -127,6 +131,26 @@ class PyLegendDateTimeColumnExpression(PyLegendDateColumnExpression, PyLegendExp
 
 
 class PyLegendStrictDateColumnExpression(PyLegendDateColumnExpression, PyLegendExpressionStrictDateReturn):
+
+    def __init__(self, row: "AbstractTdsRow", column: str) -> None:
+        super().__init__(row=row, column=column)
+
+
+class PyLegendTimeColumnExpression(PyLegendColumnExpression, PyLegendExpressionTimeReturn):
+
+    def __init__(self, row: "AbstractTdsRow", column: str) -> None:
+        super().__init__(row=row, column=column)
+
+
+class PyLegendVariantColumnExpression(PyLegendColumnExpression, PyLegendExpressionStringReturn):
+    """Column expression for VARIANT/JSON columns; string-compatible for path-access operations."""
+
+    def __init__(self, row: "AbstractTdsRow", column: str) -> None:
+        super().__init__(row=row, column=column)
+
+
+class PyLegendBinaryColumnExpression(PyLegendColumnExpression, PyLegendExpressionStringReturn):
+    """Column expression for BINARY/VARBINARY columns; string-compatible for hex-string access."""
 
     def __init__(self, row: "AbstractTdsRow", column: str) -> None:
         super().__init__(row=row, column=column)

--- a/pylegend/core/language/shared/expression.py
+++ b/pylegend/core/language/shared/expression.py
@@ -37,7 +37,8 @@ __all__: PyLegendSequence[str] = [
     "PyLegendExpressionDateReturn",
     "PyLegendExpressionDateTimeReturn",
     "PyLegendExpressionStrictDateReturn",
-    "PyLegendExpressionNullReturn"
+    "PyLegendExpressionNullReturn",
+    "PyLegendExpressionTimeReturn",
 ]
 
 
@@ -103,5 +104,12 @@ class PyLegendExpressionStrictDateReturn(PyLegendExpressionDateReturn, metaclass
 
 
 class PyLegendExpressionNullReturn(PyLegendExpression, metaclass=ABCMeta):
+    def get_leaf_expressions(self) -> PyLegendSequence["PyLegendExpression"]:
+        return [self]
+
+
+class PyLegendExpressionTimeReturn(PyLegendExpression, metaclass=ABCMeta):
+    """Expression return type for TIME values (time-of-day without a date component)."""
+
     def get_leaf_expressions(self) -> PyLegendSequence["PyLegendExpression"]:
         return [self]

--- a/pylegend/core/language/shared/primitives/__init__.py
+++ b/pylegend/core/language/shared/primitives/__init__.py
@@ -40,7 +40,10 @@ from pylegend.core.language.shared.primitives.precise_primitives import (
     PyLegendFloat4,
     PyLegendDouble,
     PyLegendNumeric,
+    PyLegendVariant,
+    PyLegendBinary,
 )
+from pylegend.core.language.shared.primitives.time import PyLegendTime
 
 
 __all__: PyLegendSequence[str] = [
@@ -68,4 +71,7 @@ __all__: PyLegendSequence[str] = [
     "PyLegendFloat4",
     "PyLegendDouble",
     "PyLegendNumeric",
+    "PyLegendTime",
+    "PyLegendVariant",
+    "PyLegendBinary",
 ]

--- a/pylegend/core/language/shared/primitives/precise_primitives.py
+++ b/pylegend/core/language/shared/primitives/precise_primitives.py
@@ -42,6 +42,8 @@ __all__: PyLegendSequence[str] = [
     "PyLegendUSmallInt",
     "PyLegendInt",
     "PyLegendUInt",
+    "PyLegendVariant",
+    "PyLegendBinary",
     "PyLegendBigInt",
     "PyLegendUBigInt",
     "PyLegendVarchar",
@@ -247,6 +249,44 @@ class PyLegendNumeric(PyLegendDecimal):
     @property
     def scale(self) -> int:
         return self.__scale  # pragma: no cover
+
+    def to_sql_expression(
+            self,
+            frame_name_to_base_query_map: PyLegendDict[str, QuerySpecification],
+            config: FrameToSqlConfig
+    ) -> Expression:
+        return super().to_sql_expression(frame_name_to_base_query_map, config)
+
+
+class PyLegendVariant(PyLegendString):
+    """Precise primitive: Variant – semi-structured / JSON column (Snowflake VARIANT, DuckDB JSON).
+
+    String-compatible so JSON-path operations and equality checks work without
+    a separate operation set.  Dedicated JSON-extraction helpers can be added
+    as follow-up PRs once the Pure built-ins are exposed.
+    """
+
+    def __init__(self, value: PyLegendExpressionStringReturn) -> None:
+        super().__init__(value)
+
+    def to_sql_expression(
+            self,
+            frame_name_to_base_query_map: PyLegendDict[str, QuerySpecification],
+            config: FrameToSqlConfig
+    ) -> Expression:
+        return super().to_sql_expression(frame_name_to_base_query_map, config)
+
+
+class PyLegendBinary(PyLegendString):
+    """Precise primitive: Binary – raw byte array column (BINARY / VARBINARY / BYTEA).
+
+    String-compatible because binary data is most commonly accessed via
+    hex-string representation in SQL.  Byte-level operations can be added
+    in follow-up PRs.
+    """
+
+    def __init__(self, value: PyLegendExpressionStringReturn) -> None:
+        super().__init__(value)
 
     def to_sql_expression(
             self,

--- a/pylegend/core/language/shared/primitives/time.py
+++ b/pylegend/core/language/shared/primitives/time.py
@@ -1,0 +1,71 @@
+# Copyright 2026 Goldman Sachs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Time-of-day primitive type for the PyLegend expression language.
+
+``PyLegendTime`` represents a TIME column value (hour, minute, second,
+optional fractional seconds) with no date component.  It maps to the
+``Time`` primitive type in Legend's Pure type system, and to the SQL
+``TIME`` type in Snowflake, DuckDB, and Databricks.
+
+Instances are produced when a column whose Legend type is ``Time`` is
+accessed on a TDS frame.
+"""
+
+from pylegend._typing import (
+    PyLegendSequence,
+    PyLegendDict,
+)
+from pylegend.core.language.shared.primitives.primitive import PyLegendPrimitive
+from pylegend.core.language.shared.expression import PyLegendExpressionTimeReturn
+from pylegend.core.sql.metamodel import (
+    Expression,
+    QuerySpecification,
+)
+from pylegend.core.tds.tds_frame import FrameToSqlConfig
+from pylegend.core.tds.tds_frame import FrameToPureConfig
+
+
+__all__: PyLegendSequence[str] = [
+    "PyLegendTime",
+]
+
+
+class PyLegendTime(PyLegendPrimitive):
+    """TIME expression type — time-of-day without a date component.
+
+    Supports equality, null checks, and string conversion (inherited from
+    ``PyLegendPrimitive``).  Time-arithmetic and extraction functions
+    (e.g. ``hour()``, ``minute()``) can be added in follow-up PRs as
+    the corresponding Pure built-ins are exposed.
+    """
+
+    __value: PyLegendExpressionTimeReturn
+
+    def __init__(self, value: PyLegendExpressionTimeReturn) -> None:
+        self.__value = value
+
+    def to_sql_expression(
+            self,
+            frame_name_to_base_query_map: PyLegendDict[str, QuerySpecification],
+            config: FrameToSqlConfig
+    ) -> Expression:
+        return self.__value.to_sql_expression(frame_name_to_base_query_map, config)
+
+    def to_pure_expression(self, config: FrameToPureConfig) -> str:
+        return self.__value.to_pure_expression(config)
+
+    def value(self) -> PyLegendExpressionTimeReturn:
+        return self.__value

--- a/pylegend/core/language/type_factory.py
+++ b/pylegend/core/language/type_factory.py
@@ -51,6 +51,11 @@ __all__: PyLegendSequence[str] = [
     # Parameterized types
     "varchar",
     "numeric",
+
+    # Unstructured / binary types
+    "time",
+    "variant",
+    "binary",
 ]
 
 
@@ -179,3 +184,18 @@ def numeric(precision: builtins.int, scale: builtins.int) -> CastTarget:  # noqa
         frame.cast({"amount": pylegend.type_factory.numeric(10, 2)})
     """
     return (PrimitiveType.Numeric, precision, scale)  # type: ignore
+
+
+def time() -> CastTarget:
+    """Cast to Time (time-of-day without date; maps to SQL TIME)."""
+    return PrimitiveType.Time
+
+
+def variant() -> CastTarget:
+    """Cast to Variant (semi-structured / JSON; maps to Snowflake VARIANT or DuckDB JSON)."""
+    return PrimitiveType.Variant
+
+
+def binary() -> CastTarget:
+    """Cast to Binary (raw byte array; maps to SQL BINARY / VARBINARY / BYTEA)."""
+    return PrimitiveType.Binary

--- a/pylegend/core/tds/tds_column.py
+++ b/pylegend/core/tds/tds_column.py
@@ -78,6 +78,9 @@ class PrimitiveType(Enum):
     Float4 = 21
     Double = 22
     Numeric = 23
+    Time = 24
+    Variant = 25
+    Binary = 26
 
 
 class PrimitiveTdsColumn(TdsColumn):
@@ -183,6 +186,18 @@ class PrimitiveTdsColumn(TdsColumn):
     @classmethod
     def numeric_column(cls, name: str) -> "PrimitiveTdsColumn":
         return PrimitiveTdsColumn(name, PrimitiveType.Numeric)
+
+    @classmethod
+    def time_column(cls, name: str) -> "PrimitiveTdsColumn":
+        return PrimitiveTdsColumn(name, PrimitiveType.Time)
+
+    @classmethod
+    def variant_column(cls, name: str) -> "PrimitiveTdsColumn":
+        return PrimitiveTdsColumn(name, PrimitiveType.Variant)
+
+    @classmethod
+    def binary_column(cls, name: str) -> "PrimitiveTdsColumn":
+        return PrimitiveTdsColumn(name, PrimitiveType.Binary)
 
 
 class EnumTdsColumn(TdsColumn):

--- a/tests/core/language/shared/primitives/test_new_types.py
+++ b/tests/core/language/shared/primitives/test_new_types.py
@@ -1,0 +1,135 @@
+# Copyright 2023 Goldman Sachs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the three new primitive types added by Issue #220:
+Time, Variant, and Binary.
+"""
+
+from pylegend.core.tds.tds_column import PrimitiveType, PrimitiveTdsColumn, tds_columns_from_json
+from pylegend.core.language.shared.primitives import (
+    PyLegendTime,
+    PyLegendVariant,
+    PyLegendBinary,
+)
+from pylegend.core.language import type_factory
+
+
+class TestPrimitiveTypeEnum:
+    def test_time_in_enum(self) -> None:
+        assert PrimitiveType.Time is not None
+        assert PrimitiveType.Time.name == "Time"
+
+    def test_variant_in_enum(self) -> None:
+        assert PrimitiveType.Variant is not None
+        assert PrimitiveType.Variant.name == "Variant"
+
+    def test_binary_in_enum(self) -> None:
+        assert PrimitiveType.Binary is not None
+        assert PrimitiveType.Binary.name == "Binary"
+
+    def test_no_enum_value_collision(self) -> None:
+        values = [t.value for t in PrimitiveType]
+        assert len(values) == len(set(values)), "Duplicate enum values detected"
+
+
+class TestPrimitiveTdsColumnFactoryMethods:
+    def test_time_column_factory(self) -> None:
+        col = PrimitiveTdsColumn.time_column("arrival_time")
+        assert col.get_name() == "arrival_time"
+        assert col.get_type() == "Time"
+
+    def test_variant_column_factory(self) -> None:
+        col = PrimitiveTdsColumn.variant_column("metadata")
+        assert col.get_name() == "metadata"
+        assert col.get_type() == "Variant"
+
+    def test_binary_column_factory(self) -> None:
+        col = PrimitiveTdsColumn.binary_column("payload")
+        assert col.get_name() == "payload"
+        assert col.get_type() == "Binary"
+
+    def test_time_column_copy(self) -> None:
+        col = PrimitiveTdsColumn.time_column("ts")
+        copy = col.copy()
+        assert copy.get_type() == "Time"
+        assert copy.get_name() == "ts"
+
+    def test_time_column_copy_with_changed_name(self) -> None:
+        col = PrimitiveTdsColumn.time_column("old")
+        renamed = col.copy_with_changed_name("new")
+        assert renamed.get_name() == "new"
+        assert renamed.get_type() == "Time"
+
+
+class TestTypeFactory:
+    def test_time_cast_target(self) -> None:
+        target = type_factory.time()
+        assert target == PrimitiveType.Time
+
+    def test_variant_cast_target(self) -> None:
+        target = type_factory.variant()
+        assert target == PrimitiveType.Variant
+
+    def test_binary_cast_target(self) -> None:
+        target = type_factory.binary()
+        assert target == PrimitiveType.Binary
+
+
+class TestTdsColumnsFromJson:
+    """Verify that tds_columns_from_json correctly round-trips new types."""
+
+    def test_time_roundtrip(self) -> None:
+        schema_json = '{"columns": [{"_type": "primitiveSchemaColumn", "name": "ts", "type": "Time"}]}'
+        cols = tds_columns_from_json(schema_json)
+        assert len(cols) == 1
+        assert cols[0].get_name() == "ts"
+        assert cols[0].get_type() == "Time"
+
+    def test_variant_roundtrip(self) -> None:
+        schema_json = '{"columns": [{"_type": "primitiveSchemaColumn", "name": "meta", "type": "Variant"}]}'
+        cols = tds_columns_from_json(schema_json)
+        assert cols[0].get_type() == "Variant"
+
+    def test_binary_roundtrip(self) -> None:
+        schema_json = '{"columns": [{"_type": "primitiveSchemaColumn", "name": "data", "type": "Binary"}]}'
+        cols = tds_columns_from_json(schema_json)
+        assert cols[0].get_type() == "Binary"
+
+
+class TestPyLegendVariantIsStringCompatible:
+    """Variant inherits PyLegendString so string operations work."""
+
+    def test_variant_is_subclass_of_string(self) -> None:
+        from pylegend.core.language.shared.primitives.string import PyLegendString
+        assert issubclass(PyLegendVariant, PyLegendString)
+
+    def test_binary_is_subclass_of_string(self) -> None:
+        from pylegend.core.language.shared.primitives.string import PyLegendString
+        assert issubclass(PyLegendBinary, PyLegendString)
+
+
+class TestPyLegendTimeType:
+    """Time is a standalone primitive (not String/Number/Date)."""
+
+    def test_time_is_subclass_of_primitive(self) -> None:
+        from pylegend.core.language.shared.primitives.primitive import PyLegendPrimitive
+        assert issubclass(PyLegendTime, PyLegendPrimitive)
+
+    def test_time_is_not_subclass_of_string(self) -> None:
+        from pylegend.core.language.shared.primitives.string import PyLegendString
+        assert not issubclass(PyLegendTime, PyLegendString)
+
+    def test_time_is_not_subclass_of_date(self) -> None:
+        from pylegend.core.language.shared.primitives.date import PyLegendDate
+        assert not issubclass(PyLegendTime, PyLegendDate)


### PR DESCRIPTION
 Closes #220

  ## What this does

  Adds the three missing primitive types requested in Issue #220 through the full type chain.

  ### Changes by layer

  | Layer | Change |
  |-------|--------|
  | `PrimitiveType` enum | `Time=24`, `Variant=25`, `Binary=26` |
  | `PrimitiveTdsColumn` | `.time_column()`, `.variant_column()`, `.binary_column()` factory methods |
  | Expression return type | `PyLegendExpressionTimeReturn` ABC |
  | Column expressions | `PyLegendTimeColumnExpression`, `PyLegendVariantColumnExpression`, `PyLegendBinaryColumnExpression` |
  | Language primitives | `PyLegendTime` (standalone); `PyLegendVariant`/`PyLegendBinary` extend `PyLegendString` |
  | Cast functions | `type_factory.time()`, `type_factory.variant()`, `type_factory.binary()` |

  `tds_columns_from_json` correctly round-trips all three new types (type name resolved by string).

  **Variant/Binary as String:** intentional — both serialize to strings in standard query
  engines (JSON for Variant, hex for Binary). Time-arithmetic functions can follow.

  ## Tests

  ```bash
  pytest tests/core/language/shared/primitives/test_new_types.py -v  # 20 passed
  # Existing tds_column tests: 9/9 unaffected
  # flake8 --max-line-length=127: clean
  # mypy --strict: clean
```
